### PR TITLE
Prompt "TIL" messages to create blog post ideas

### DIFF
--- a/scripts/til.coffee
+++ b/scripts/til.coffee
@@ -1,0 +1,14 @@
+# Description:
+#   Searches for TIL posts and offers to make blog post issues for them
+#
+# Commands:
+#   hubot til weekly hangout
+
+module.exports = (robot) ->
+  robot.hear /TIL (.+)/i, (msg) ->
+    title = encodeURI("[TIL] Blog Post Idea")
+    til_post = encodeURI(msg.match[0])
+
+    message = "That looks like a good TIL post! Click here to post it as an issue to the blog: "
+    url = "https://github.com/testdouble/double-takes/issues/new?title=#{title}&body=#{til_post}"
+    msg.reply message + url


### PR DESCRIPTION
Fixes #2 in the simplest way possible

# Reasoning
At the summer retreat, we discussed creating blog posts out of the large number of "TIL" posts in Slack. I had some time on the way home from Columbus so I thought this would be a good project to tackle.

# Ideal Approach
At first, I wanted to automatically create a PR that others could edit or just instapost if it was ready enough. This could be done, but would involve:
1. Creating a branch with the new file.
    * https://developer.github.com/v3/git/refs/#create-a-reference
2. Creating a new file with the contents and a unique path (`app/posts/#{Date.today.iso8601}-post-title`).
    * https://developer.github.com/v3/repos/contents/#create-a-file
3. Creating a pull request with the new branch.
    * https://developer.github.com/v3/pulls/#create-a-pull-request

This seemed like an ideal solution, as one would simply have to merge and deploy to publish the new post. Unfortunately...
* That's a logic to throw into `doubot`. It would probably be better as a Hubot plugin.
* It would require GitHub credentials for a user that can create PRs against `double-takes`.
* It would require multiple API calls, all of which could fail.
* I'm writing all of this on the way home from Columbus on an iPhone.

Something had to give.

# Compromised Second Draft
In lieu of that, I've created this alternate workflow:
1. Create a URL that will post an issue on https://github.com/testdouble/double-takes with a static title and the message typed as the body.

This nudges the original sender to create a blog post if they'd like. It also can let the sender create a placeholder issue for the message so that another agent could post it as a `TIL` or flesh it out into a fully-fledged blog post.

As this is a first crack at it and there were numerous approaches brought up at the retreat, I'd welcome feedback, improvements, even rejections if someone sees a better initial approach for this 😄.

# Behavior
![til-doubot](https://user-images.githubusercontent.com/282048/27008644-1dc55ab4-4e45-11e7-8a9f-0b6099f22093.gif)
